### PR TITLE
Fixed parse_tar()'s accidental infinite loop

### DIFF
--- a/src/filesystem/tar.c
+++ b/src/filesystem/tar.c
@@ -26,7 +26,7 @@ unsigned int parse_tar(unsigned int address)
  
         struct tar_header *header = (struct tar_header *)address;
  
-        if (header->filename[0] == '\0')
+        if (header->filename[i] == '\0')
             break;
  
         unsigned int size = getsize(header->size);


### PR DESCRIPTION
The function `parse_tar()` was always looking at the first element of the filename to see if a `\0` is present.
Now it checks all elements for a '\0' character.